### PR TITLE
Add ability to detect nested $TMUX and start a new session

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -288,7 +288,11 @@ for host in ${HOSTS[@]}; do
 
 	# First Call, inits the tmux-session
 	if [ "${initTmuxCall}" == "true" ]; then
-		tmux new-session -d -s "${TMUX_SESSION_NAME}" "${connectString}"
+    if [[ -n "${TMUX}" ]]; then
+      tmux -S "${TMUX%%,*}" switch-client -t "$(TMUX= tmux -S "${TMUX%%,*}" new-session -dP -s "${TMUX_SESSION_NAME}" "${connectString}")"
+    else
+		  tmux new-session -d -s "${TMUX_SESSION_NAME}" "${connectString}"
+    fi
 
     # If our initial ssh connection has failed, do not mark initTmuxCall as false since tmux will have aborted.
     # We'll need to try to start a new tmux session for the next host.


### PR DESCRIPTION
If $TMUX is set automatically tell existing tmux server (-S) to start a new session and attach to it.

After the session is closed I couldn't figure out a way to automatically connect to the previous session but at least -ns and -ts work while inside an existing tmux session.

I am going to try and add a new default option to open a new-window instead of a new session when inside a nested session. I think this would be desired outcome when already inside tmux. I will send a separate pull request for that change once I figure out where it should go.

essentially all it needs is 
`tmux -S "${TMUX%%,*}" new-window -n "${TMUX_SESSION_NAME}" "${connectString}"`
This opens a new window with the provided session name (or auto generated name) unless -ns was given.