### PR TITLE
Make more portable the script

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 THIS_BASENAME=$(basename "$0")
 TMUX_SESSION_NAME="tmux-cssh"


### PR DESCRIPTION
Make portable the script, in ubuntu system `sh` is linked to `dash` instead of bash. Bash has many more features and is especially preferable when used interactively.
