### PR TITLE
Fix window splitting with tmux 2.6

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -300,7 +300,7 @@ for host in ${HOSTS}; do
 		  initTmuxCall="false"
     fi
 	else
-    tmux split-window -t "${TMUX_SESSION_NAME}" "${connectString}" && \
+    tmux split-window -h -t "${TMUX_SESSION_NAME}" "${connectString}" && \
     tmux select-layout -t "${TMUX_SESSION_NAME}" "${TMUX_LAYOUT}"
 	fi
 done


### PR DESCRIPTION
In tmux 2.6 detached new sessions are now always 80x24 which may result
in 'create pane failed: pane too small' erros and not all panes created.
The fix is to split horizontally instead of vertically. Another way
would be to create bigger session by default by adding '-x' and '-y'
parameters to 'new-session' command as per tmux man pages:

With -d, the initial size is 80 x 24; -x and -y can be used to specify a
different size.