### PR TITLE
Create full-window pane when calling `split-window`

### DIFF
--- a/tmux-cssh
+++ b/tmux-cssh
@@ -300,7 +300,7 @@ for host in ${HOSTS}; do
 		  initTmuxCall="false"
     fi
 	else
-    tmux split-window -t "${TMUX_SESSION_NAME}" "${connectString}" && \
+    tmux split-window -fhv -t "${TMUX_SESSION_NAME}" "${connectString}" && \
     tmux select-layout -t "${TMUX_SESSION_NAME}" "${TMUX_LAYOUT}"
 	fi
 done


### PR DESCRIPTION
After updating my Mac to High Sierra, I started to get `create pane failed: pane too small` errors when using `tmux-cssh` to login to more than a handful of servers. To fix this, I've simply added `-fhv` to the `split-window` call. This ensures that every new pane starts its existence at the full size of the window. 

In my own environment (i.e. terminal window size), I couldn't get `tmux-cssh` to connect to more than ~15 servers. With this update I just successfully connected to 96 servers, which restores the functionality I was used to having until it broke in High Sierra.